### PR TITLE
use `bash` shell for Windows environment

### DIFF
--- a/azure-templates.yml
+++ b/azure-templates.yml
@@ -52,13 +52,7 @@ jobs:
         codecov -t $codecov_token
       env:
         codecov_token: $(CODECOV_TOKEN)
-      condition: ne( variables['Agent.OS'], 'Windows_NT' )
-      displayName: codecov upload on Linux/Darwin
-
-    - powershell: |
-        codecov -t "$(CODECOV_TOKEN)"
-      condition: eq( variables['Agent.OS'], 'Windows_NT' )
-      displayName: codecov upload on Windows
+      displayName: codecov upload
 
     - task: PublishTestResults@2
       condition: succeededOrFailed()


### PR DESCRIPTION
this is to fix an issue with Windows codecov upload:
https://dev.azure.com/spacetelescope/wiimatch/_build/results?buildId=5066&view=logs&j=9b504e82-4fb9-54cf-b3b1-b053f9f21a18&t=31c5e37e-64e2-5113-3b59-0dba1a98a9d9
```
CODECOV_TOKEN : The term 'CODECOV_TOKEN' is not recognized as the name of a cmdlet, function, script file, or operable 
program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
At D:\a\_temp\508d2d2e-0837-4ae4-a67d-2efdec5104b1.ps1:3 char:15
+ codecov -t "$(CODECOV_TOKEN)"
+               ~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (CODECOV_TOKEN:String) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : CommandNotFoundException
```