### PR TITLE
Update code to reduce numpy warnings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,8 +4,13 @@
 Release Notes
 =============
 
-.. 0.2.1 (unreleased)
+.. 0.2.2 (unreleased)
    ==================
+
+0.2.1 (unreleased)
+==================
+
+- Updated code to reduce warnings with latest ``numpy`` versions. [#16]
 
 
 0.2.0 (07-August-2019)

--- a/wiimatch/lsq_optimizer.py
+++ b/wiimatch/lsq_optimizer.py
@@ -127,12 +127,12 @@ def build_lsq_eqs(images, masks, sigmas, degree, center=None,
     --------
     >>> import wiimatch
     >>> import numpy as np
-    >>> im1 = np.zeros((5, 5, 4), dtype=np.float)
+    >>> im1 = np.zeros((5, 5, 4), dtype=float)
     >>> cbg = 1.32 * np.ones_like(im1)
-    >>> ind = np.indices(im1.shape, dtype=np.float)
+    >>> ind = np.indices(im1.shape, dtype=float)
     >>> im3 = cbg + 0.15 * ind[0] + 0.62 * ind[1] + 0.74 * ind[2]
     >>> mask = np.ones_like(im1, dtype=np.int8)
-    >>> sigma = np.ones_like(im1, dtype=np.float)
+    >>> sigma = np.ones_like(im1, dtype=float)
     >>> a, b, ca, ef, cs = wiimatch.lsq_optimizer.build_lsq_eqs([im1, im3],
     ... [mask, mask], [sigma, sigma], degree=(1, 1, 1), center=(0, 0, 0))
     >>> print(a)
@@ -206,8 +206,8 @@ def build_lsq_eqs(images, masks, sigmas, degree, center=None,
     )
 
     # allocate array for the coefficients of the system of equations (a*x=b):
-    a = np.zeros((sys_eq_array_size, sys_eq_array_size), dtype=np.float)
-    b = np.zeros(sys_eq_array_size, dtype=np.float)
+    a = np.zeros((sys_eq_array_size, sys_eq_array_size), dtype=float)
+    b = np.zeros(sys_eq_array_size, dtype=float)
 
     for i in range(sys_eq_array_size):
         # decompose first (row, or eq) flat index into "original" indices:
@@ -309,12 +309,12 @@ def pinv_solve(matrix, free_term, nimages, tol=None):
     --------
     >>> import wiimatch
     >>> import numpy as np
-    >>> im1 = np.zeros((5, 5, 4), dtype=np.float)
+    >>> im1 = np.zeros((5, 5, 4), dtype=float)
     >>> cbg = 1.32 * np.ones_like(im1)
-    >>> ind = np.indices(im1.shape, dtype=np.float)
+    >>> ind = np.indices(im1.shape, dtype=float)
     >>> im3 = cbg + 0.15 * ind[0] + 0.62 * ind[1] + 0.74 * ind[2]
     >>> mask = np.ones_like(im1, dtype=np.int8)
-    >>> sigma = np.ones_like(im1, dtype=np.float)
+    >>> sigma = np.ones_like(im1, dtype=float)
     >>> a, b, _, _, _ = wiimatch.lsq_optimizer.build_lsq_eqs([im1, im3],
     ... [mask, mask], [sigma, sigma], degree=(1, 1, 1), center=(0, 0, 0))
     >>> wiimatch.lsq_optimizer.pinv_solve(a, b, 2) # doctest: +FLOAT_CMP
@@ -370,12 +370,12 @@ def rlu_solve(matrix, free_term, nimages):
     --------
     >>> import wiimatch
     >>> import numpy as np
-    >>> im1 = np.zeros((5, 5, 4), dtype=np.float)
+    >>> im1 = np.zeros((5, 5, 4), dtype=float)
     >>> cbg = 1.32 * np.ones_like(im1)
-    >>> ind = np.indices(im1.shape, dtype=np.float)
+    >>> ind = np.indices(im1.shape, dtype=float)
     >>> im3 = cbg + 0.15 * ind[0] + 0.62 * ind[1] + 0.74 * ind[2]
     >>> mask = np.ones_like(im1, dtype=np.int8)
-    >>> sigma = np.ones_like(im1, dtype=np.float)
+    >>> sigma = np.ones_like(im1, dtype=float)
     >>> a, b, _, _, _ = wiimatch.lsq_optimizer.build_lsq_eqs([im1, im3],
     ... [mask, mask], [sigma, sigma], degree=(1, 1, 1), center=(0, 0, 0))
     >>> wiimatch.lsq_optimizer.rlu_solve(a, b, 2)   # doctest: +FLOAT_CMP
@@ -389,7 +389,7 @@ def rlu_solve(matrix, free_term, nimages):
     """
     drop = free_term.size // nimages
     if nimages <= 1:
-        return np.zeros((1, drop), dtype=np.float)
+        return np.zeros((1, drop), dtype=float)
     from scipy import linalg
     rmat = matrix[drop:, drop:]
     v = linalg.lu_solve(linalg.lu_factor(rmat),
@@ -422,7 +422,7 @@ def _image_pixel_sum(image_l, image_m, mask_l, mask_m,
 
         return np.sum((image_l[cmask] - image_m[cmask]) /
                       (sigma2_l[cmask] + sigma2_m[cmask]),
-                      dtype=np.float)
+                      dtype=float)
 
     if len(coord_arrays) != len(p):
         raise ValueError("Lengths of the list of pixel index arrays and "
@@ -438,7 +438,7 @@ def _image_pixel_sum(image_l, image_m, mask_l, mask_m,
 
     return np.sum(i[cmask] * (image_l[cmask] - image_m[cmask]) /
                   (sigma2_l[cmask] + sigma2_m[cmask]),
-                  dtype=np.float)
+                  dtype=float)
 
 
 def _sigma_pixel_sum(mask_l, mask_m, sigma2_l, sigma2_m,
@@ -460,7 +460,7 @@ def _sigma_pixel_sum(mask_l, mask_m, sigma2_l, sigma2_m,
                              "must be None as well.")
 
         return np.sum(1.0 / (sigma2_l[cmask] + sigma2_m[cmask]),
-                      dtype=np.float)
+                      dtype=float)
 
     if len(coord_arrays) != len(p) or len(p) != len(pp):
         raise ValueError("Lengths of the list of pixel index arrays and "
@@ -476,4 +476,4 @@ def _sigma_pixel_sum(mask_l, mask_m, sigma2_l, sigma2_m,
         i *= c**(ip + ipp)
 
     return np.sum(i[cmask] / (sigma2_l[cmask] + sigma2_m[cmask]),
-                  dtype=np.float)
+                  dtype=float)

--- a/wiimatch/match.py
+++ b/wiimatch/match.py
@@ -156,12 +156,12 @@ def match_lsq(images, masks=None, sigmas=None, degree=0,
     --------
     >>> import wiimatch
     >>> import numpy as np
-    >>> im1 = np.zeros((5, 5, 4), dtype=np.float)
+    >>> im1 = np.zeros((5, 5, 4), dtype=float)
     >>> cbg = 1.32 * np.ones_like(im1)
-    >>> ind = np.indices(im1.shape, dtype=np.float)
+    >>> ind = np.indices(im1.shape, dtype=float)
     >>> im3 = cbg + 0.15 * ind[0] + 0.62 * ind[1] + 0.74 * ind[2]
     >>> mask = np.ones_like(im1, dtype=np.int8)
-    >>> sigma = np.ones_like(im1, dtype=np.float)
+    >>> sigma = np.ones_like(im1, dtype=float)
     >>> wiimatch.match.match_lsq([im1, im3], [mask, mask], [sigma, sigma],
     ... degree=(1,1,1), center=(0,0,0))   # doctest: +FLOAT_CMP
     array([[-6.60000000e-01, -7.50000000e-02, -3.10000000e-01,
@@ -185,7 +185,7 @@ def match_lsq(images, masks=None, sigmas=None, degree=0,
     # check that the number of good pixel mask arrays matches the numbers
     # of input images, and if 'masks' is None - set all of them to True:
     if masks is None:
-        masks = [np.ones_like(images[0], dtype=np.bool) for i in images]
+        masks = [np.ones_like(images[0], dtype=bool) for i in images]
 
     else:
         if len(masks) != nimages:
@@ -204,7 +204,7 @@ def match_lsq(images, masks=None, sigmas=None, degree=0,
     # check that the number of sigma arrays matches the numbers
     # of input images, and if 'sigmas' is None - set all of them to 1:
     if sigmas is None:
-        sigmas = [np.ones_like(images[0], dtype=np.float) for i in images]
+        sigmas = [np.ones_like(images[0], dtype=float) for i in images]
 
     else:
         if len(sigmas) != nimages:

--- a/wiimatch/tests/test_match.py
+++ b/wiimatch/tests/test_match.py
@@ -14,15 +14,15 @@ from wiimatch import match
 def test_match_lsq_solver(solver):
     # simulate background image data:
     c = [1.32, 0.15, 0.62, 0, 0.74, 0, 0, 0]
-    im1 = np.zeros((5, 5, 4), dtype=np.float)
+    im1 = np.zeros((5, 5, 4), dtype=float)
     cbg = c[0] * np.ones_like(im1)  # constand background level image
 
     # add slope:
-    ind = np.indices(im1.shape, dtype=np.float)
+    ind = np.indices(im1.shape, dtype=float)
     im3 = cbg + c[1] * ind[0] + c[2] * ind[1] + c[4] * ind[2]
 
     mask = np.ones_like(im1, dtype=np.int8)
-    sigma = np.ones_like(im1, dtype=np.float)
+    sigma = np.ones_like(im1, dtype=float)
 
     p = match.match_lsq(
         [im1, im3], [mask, mask], [sigma, sigma],
@@ -36,15 +36,15 @@ def test_match_lsq_solver(solver):
 def test_match_lsq_extended_return():
     # simulate background image data:
     c = [1.32, 0.15, 0.62, 0, 0.74, 0, 0, 0]
-    im1 = np.zeros((5, 5, 4), dtype=np.float)
+    im1 = np.zeros((5, 5, 4), dtype=float)
     cbg = c[0] * np.ones_like(im1)  # constand background level image
 
     # add slope:
-    ind = np.indices(im1.shape, dtype=np.float)
+    ind = np.indices(im1.shape, dtype=float)
     im3 = cbg + c[1] * ind[0] + c[2] * ind[1] + c[4] * ind[2]
 
     mask = np.ones_like(im1, dtype=np.int8)
-    sigma = np.ones_like(im1, dtype=np.float)
+    sigma = np.ones_like(im1, dtype=float)
 
     p, a, b, coord_arrays, eff_center, coord_system = match.match_lsq(
         [im1, im3], [mask, mask], [sigma, sigma],
@@ -59,15 +59,15 @@ def test_match_lsq_extended_return():
 def test_match_lsq_num_degree(degree):
     # simulate background image data:
     c = [1.32, 0.15, 0.62, 0, 0.74, 0, 0, 0]
-    im1 = np.zeros((5, 5, 4), dtype=np.float)
+    im1 = np.zeros((5, 5, 4), dtype=float)
     cbg = c[0] * np.ones_like(im1)  # constand background level image
 
     # add slope:
-    ind = np.indices(im1.shape, dtype=np.float)
+    ind = np.indices(im1.shape, dtype=float)
     im3 = cbg + c[1] * ind[0] + c[2] * ind[1] + c[4] * ind[2]
 
     mask = np.ones_like(im1, dtype=np.int8)
-    sigma = np.ones_like(im1, dtype=np.float)
+    sigma = np.ones_like(im1, dtype=float)
 
     p = match.match_lsq(
         [im1, im3], [mask, mask], [sigma, sigma],

--- a/wiimatch/tests/test_utils.py
+++ b/wiimatch/tests/test_utils.py
@@ -13,7 +13,7 @@ def test_utils_coordinates():
     image_shape = (3, 5, 4)
     center = (0, 0, 0)
     c = utils.create_coordinate_arrays(image_shape, center=center)
-    ind = np.indices(image_shape, dtype=np.float)[::-1]
+    ind = np.indices(image_shape, dtype=float)[::-1]
 
     assert np.allclose(c[0], ind, rtol=1.e-8, atol=1.e-12)
     assert np.allclose(c[1], center, rtol=1.e-8, atol=1.e-12)
@@ -22,7 +22,7 @@ def test_utils_coordinates():
 def test_utils_coordinates_no_center():
     image_shape = (3, 5, 4)
     c = utils.create_coordinate_arrays(image_shape, center=None)
-    ind = np.indices(image_shape, dtype=np.float)[::-1]
+    ind = np.indices(image_shape, dtype=float)[::-1]
 
     center = tuple(i // 2 for i in image_shape)
     for orig, cc, i in zip(center, c[0], ind):

--- a/wiimatch/utils.py
+++ b/wiimatch/utils.py
@@ -131,7 +131,7 @@ def create_coordinate_arrays(image_shape, center=None, image2world=None,
             raise ValueError("'center_cs' cannot be 'world' when 'image2world'"
                              " is not defined.")
 
-    ind = np.indices(image_shape, dtype=np.float)[::-1]
+    ind = np.indices(image_shape, dtype=float)[::-1]
 
     if image2world is None:
         coord_system = 'image'


### PR DESCRIPTION
Reduce numpy deprecation warnings due to use of numpy types (e.g., `np.float`). Transition to built-in Python data types.