### PR TITLE
Fix typos in docs

### DIFF
--- a/wiimatch/lsq_optimizer.py
+++ b/wiimatch/lsq_optimizer.py
@@ -239,7 +239,8 @@ def build_lsq_eqs(images, masks, sigmas, degree, center=None,
             m = mp[0]
             pp = mp[1:]
 
-            if l == m:  # noqa: E741  # we will deal with this case in the next iteration
+            if l == m:  # noqa: E741
+                # we will deal with this case in the next iteration
                 continue
 
             a[i, j] = -_sigma_pixel_sum(
@@ -345,7 +346,7 @@ def rlu_solve(matrix, free_term, nimages):
     dropping equations and unknowns related to the first image. The unknowns
     corresponding to the first image initially are assumed to be 0.
     Upon solving the reduced system, these unknowns are recomputed so that
-    mean corection coefficients for all images are 0.
+    mean correction coefficients for all images are 0.
     This function uses `~scipy.linalg.lu_solve` and
     `~scipy.linalg.lu_factor` functions.
 

--- a/wiimatch/match.py
+++ b/wiimatch/match.py
@@ -172,6 +172,15 @@ def match_lsq(images, masks=None, sigmas=None, degree=0,
              5.96855898e-16, -2.98427949e-16]])
 
     """
+    solver = solver.upper()
+    if solver not in SUPPORTED_SOLVERS:
+        ns = len(SUPPORTED_SOLVERS)
+        raise ValueError("'solver' must be one of the supported solvers: '{}'"
+                         .format(SUPPORTED_SOLVERS[0] if ns == 1 else
+                                 '\', \''.join(SUPPORTED_SOLVERS[:-1]) +
+                                 '\'' + (',' if ns > 2 else '') +
+                                 ' or \'{}'.format(SUPPORTED_SOLVERS[-1])))
+
     # check that all images have the same shape:
     shapes = set([])
     for im in images:

--- a/wiimatch/utils.py
+++ b/wiimatch/utils.py
@@ -125,7 +125,7 @@ def create_coordinate_arrays(image_shape, center=None, image2world=None,
     else:
         if len(center) != len(image_shape):
             raise ValueError("Number of coordinates of the 'center' must "
-                             "match the dimentionality of the image.")
+                             "match the dimensionality of the image.")
 
         if center_cs == 'world' and image2world is None:
             raise ValueError("'center_cs' cannot be 'world' when 'image2world'"


### PR DESCRIPTION
This PR fixes typos in the doc strings and adds a check that input `solver` argument is supported.