### PR TITLE
Use importlib instead of deprecated pkg_resources

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,6 +53,8 @@ jobs:
       architecture: 'x64'
 
   - script: |
+      python -m pip install setuptools
+      python -m pip install setuptools_scm
       python -m pip install astropy
       python setup.py sdist
     displayName: 'Build sdist'

--- a/azure-templates.yml
+++ b/azure-templates.yml
@@ -10,12 +10,14 @@ jobs:
 
   strategy:
     matrix:
-      Python38:
-        python.version: '3.8'
       Python39:
         python.version: '3.9'
       Python310:
         python.version: '3.10'
+      Python311:
+        python.version: '3.11'
+      Python312:
+        python.version: '3.12'
     maxParallel: 4
 
   steps:
@@ -69,4 +71,3 @@ jobs:
       inputs:
         testResultsFiles: '**/test-*.xml'
         testRunTitle: 'Python $(python.version)-${{ format(parameters.name) }}'
-

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(
     ],
     use_scm_version=True,
     setup_requires=SETUP_REQUIRES,
-    python_requires='>=3.5',
+    python_requires='>=3.7',
     install_requires=INSTALL_REQUIRES,
     tests_require=TESTS_REQUIRE,
     packages=find_packages(),

--- a/wiimatch/__init__.py
+++ b/wiimatch/__init__.py
@@ -1,15 +1,14 @@
 """wiimatch"""
-from pkg_resources import get_distribution, DistributionNotFound
 
 
 __docformat__ = 'restructuredtext en'
 __author__ = 'Mihai Cara'
 
 
+from importlib.metadata import PackageNotFoundError, version
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
-    # package is not installed
+    __version__ = version(__name__)
+except PackageNotFoundError:
     __version__ = 'UNKNOWN'
 
 


### PR DESCRIPTION
Use `importlib` instead of the deprecated `pkg_resources`. Update test matrix to include Python 3.12.